### PR TITLE
Fix TFX pipeline DAG dependencies, add back in ExampleValidator component

### DIFF
--- a/workshops/tfx-caip-tf23/lab-02-tfx-pipeline/labs/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-02-tfx-pipeline/labs/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 

--- a/workshops/tfx-caip-tf23/lab-02-tfx-pipeline/solutions/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-02-tfx-pipeline/solutions/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 

--- a/workshops/tfx-caip-tf23/lab-03-tfx-cicd/labs/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-03-tfx-cicd/labs/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 

--- a/workshops/tfx-caip-tf23/lab-03-tfx-cicd/solutions/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-03-tfx-cicd/solutions/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 

--- a/workshops/tfx-caip-tf23/lab-04-tfx-metadata/labs/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-04-tfx-metadata/labs/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 

--- a/workshops/tfx-caip-tf23/lab-04-tfx-metadata/solutions/pipeline/pipeline.py
+++ b/workshops/tfx-caip-tf23/lab-04-tfx-metadata/solutions/pipeline/pipeline.py
@@ -112,15 +112,15 @@ def create_pipeline(pipeline_name: Text,
   # Computes statistics over data for visualization and example validation.
   statisticsgen = StatisticsGen(examples=examplegen.outputs.examples)
 
+  # Generates schema based on statistics files. Even though, we use user-provided schema
+  # we still want to generate the schema of the newest data for tracking and comparison
+  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
+
   # Import a user-provided schema
   import_schema = ImporterNode(
       instance_name='import_user_schema',
       source_uri=SCHEMA_FOLDER,
       artifact_type=Schema)
-  
-  # Generates schema based on statistics files. Even though, we use user-provided schema
-  # we still want to generate the schema of the newest data for tracking and comparison
-  schemagen = SchemaGen(statistics=statisticsgen.outputs.statistics)
 
   # Performs anomaly detection based on statistics and data schema.
   examplevalidator = ExampleValidator(
@@ -242,10 +242,10 @@ def create_pipeline(pipeline_name: Text,
 
   components=[
       examplegen, 
-      statisticsgen, 
-      import_schema, 
-      schemagen, 
-      examplegen, 
+      statisticsgen,
+      schemagen,      
+      import_schema,
+      examplevalidator,
       transform,
       trainer, 
       resolver, 


### PR DESCRIPTION
- Re-order pipeline components for intended execution order.
- Correct spelling error in component list to add back in ExampleValidator to generate anomalies artifacts.