### PR TITLE
Fixes tfx-caip-tf23 workshop link.

### DIFF
--- a/workshops/README.md
+++ b/workshops/README.md
@@ -3,7 +3,7 @@
 This section contains hands on labs to support the delivery of instructor led ML Engineering workshops. The labs have been grouped into series where each series focuses on a single ML Engineering use case. 
 
 - [Continuous training with scikit-learn and Cloud AI Platform ](kfp-caip-sklearn)
-- [Continuous training with TensorFlow 2.1, TFX 0.21 and Cloud AI Platform](tfx-caip-tf21)
+- [Continuous training with TensorFlow 2.3, TFX 0.25 and Cloud AI Platform](tfx-caip-tf23)
 
 
 


### PR DESCRIPTION
Updates link to match new directory name and version info.