### PR TITLE
pin_tf_serving_image_2.8.0

### DIFF
--- a/workshops/mlep-qwiklabs/tfserving-gke-autoscaling/tf-serving/deployment.yaml
+++ b/workshops/mlep-qwiklabs/tfserving-gke-autoscaling/tf-serving/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: tf-serving
-        image: "tensorflow/serving"
+        image: "tensorflow/serving:2.8.0"
         args: 
         - "--model_name=$(MODEL_NAME)"
         - "--model_base_path=$(MODEL_PATH)" 


### PR DESCRIPTION
Current version of tf-serving is not functional for Qwiklab demo. Need to roll back the version in deployment.yaml (e.g., 2.8.0), otherwise everything after task 8 is not possible.