### PR TITLE
aligned with this commit https://github.com/GoogleCloudPlatform/mlops…

### DIFF
--- a/workshops/tfx-caip-tf23/lab-03-tfx-cicd/labs/tfx-cli/requirements.txt
+++ b/workshops/tfx-caip-tf23/lab-03-tfx-cicd/labs/tfx-cli/requirements.txt
@@ -1,3 +1,4 @@
 pandas>1.0.0
 tfx==0.25.0
 kfp==1.0.4
+requests-toolbelt==0.10.1

--- a/workshops/tfx-caip-tf23/requirements.txt
+++ b/workshops/tfx-caip-tf23/requirements.txt
@@ -1,3 +1,4 @@
 pandas>1.0.0
 tfx==0.25.0
 kfp==1.0.4
+requests-toolbelt==0.10.1


### PR DESCRIPTION
Ajay's PR https://github.com/GoogleCloudPlatform/mlops-on-gcp/commit/da9736a3da513b302bca7d4557472ea890e3c13e fixed the bug for running cloud build in the notebook, but not for github GCP cloud build trigger, just to align the changes here